### PR TITLE
Increase browser compatibility

### DIFF
--- a/wayfarer-review-map-mods.user.js
+++ b/wayfarer-review-map-mods.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name         Wayfarer Review Map Mods
-// @version      0.4.6
+// @version      0.4.7
 // @description  Add Map Mods to Wayfarer Review Page
 // @namespace    https://github.com/tehstone/wayfarer-addons
 // @downloadURL  https://github.com/tehstone/wayfarer-addons/raw/main/wayfarer-review-map-mods.user.js
@@ -104,13 +104,13 @@ function init() {
         let gmap;
         if (document.querySelector('app-location-accuracy nia-map')) {
             gmap = document.querySelector('app-location-accuracy nia-map');
-            mapCtx = gmap.__ngContext__.at(-1);
+            mapCtx = gmap.__ngContext__[gmap.__ngContext__.length - 1];
             map = mapCtx.componentRef.map;
             map.setZoom(17);
             addNearbyTooltips();
         } else if (document.querySelector("app-select-location-edit")) {
             gmap = document.querySelector("app-select-location-edit");
-            mapCtx = gmap.__ngContext__.at(-1).niaMap;
+            mapCtx = gmap.__ngContext__[gmap.__ngContext__.length - 1].niaMap;
             map = mapCtx.componentRef.map;
         }
         else {


### PR DESCRIPTION
I couldn't use map mods on my old (2011) chromebook as the chromium version it runs does not support the javascript at() function. As the function isn't really needed I replaced it to increase comparability with older browsers. These browsers do still support Wayfarer so it might be worthwhile to upstream this change.

However most users will likely run (more) modern browsers so it's up to you :)