### PR TITLE
Fixed ctrl-enter not working for keyboard plugin.

### DIFF
--- a/wayfarer-keyboard-review.user.js
+++ b/wayfarer-keyboard-review.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name         Wayfarer Keyboard Review
-// @version      0.7.1
+// @version      0.7.2
 // @description  Add keyboard review to Wayfarer
 // @namespace    https://github.com/tehstone/wayfarer-addons
 // @downloadURL  https://github.com/tehstone/wayfarer-addons/raw/main/wayfarer-keyboard-review.user.js

--- a/wayfarer-keyboard-review.user.js
+++ b/wayfarer-keyboard-review.user.js
@@ -205,7 +205,7 @@
                 } else if (e.keyCode >= 49 && e.keyCode <= 57) { // 1-9 normal
                     suppress = handleCustomWhatIf(card, e.keyCode - 49);
                 } else if (e.keyCode === 13) { // Enter
-                    trySubmit(false);
+                    trySubmit(e.ctrlKey);
                 }
             } else if (isReject && e.keyCode === 27) { // escape
                 cancelReject();
@@ -241,7 +241,7 @@
             } else if (e.keyCode == 9) { // Tab
                 suppress = selectAllPhotosOK();
             } else if (e.keyCode === 13) { // Enter
-                trySubmit(false);
+                trySubmit(e.ctrlKey);
             }
         } else if (isDuplicate) {
             if (e.keyCode === 27) { // escape
@@ -270,7 +270,7 @@
                 } else if (e.keyCode === 9) {
                     suppress = setRating(e.shiftKey ? -1 : -2, false);
                 } else if (e.keyCode === 13) { // Enter
-                    trySubmit(false);
+                    trySubmit(e.ctrlKey);
                 } else if (e.keyCode === 37 || e.keyCode === 8) { // Left arrow key or backspace
                     suppress = updateRevPosition(-1, true);
                 }
@@ -287,7 +287,7 @@
             } else if (e.keyCode >= 49 && e.keyCode <= 53) { // 1-5 normal
                 suppress = setRating(e.keyCode - 49, true);
             } else if (e.keyCode === 13) { // Enter
-                trySubmit(false);
+                trySubmit(e.ctrlKey);
             } else if (e.keyCode == 81) { // Q
                 fullSizePhoto('app-should-be-wayspot');
             } else if (e.keyCode == 69) { // E
@@ -655,6 +655,7 @@
             const buttonParts = submitWrapper[0].getElementsByTagName("button");
             if (finish) {
                 buttonParts[1].click();
+		document.querySelector("button.mat-focus-indicator.mat-menu-item").click()
             } else {
                 buttonParts[0].click();
             }


### PR DESCRIPTION
trySubmit function now properly clicks "submit and finish reviewing" popup, and all calls to trySubmit now send the state of ctrl instead of false.