### PR TITLE
Allow using "A" to close supporting info

### DIFF
--- a/wayfarer-keyboard-review.user.js
+++ b/wayfarer-keyboard-review.user.js
@@ -500,7 +500,11 @@
     }
 
     function showFullSupportingInfo() {
-        if (document.getElementsByTagName('mat-dialog-container').length) return;
+        if (document.getElementsByTagName('mat-dialog-container').length){
+            const parent = document.getElementsByClassName('cdk-overlay-container')[0];
+            while (parent.firstChild) { parent.removeChild(parent.firstChild); }
+            return;
+        }
         const supportingText = document.querySelector('app-supporting-info .wf-review-card__body .bg-gray-200');
         if (supportingText) supportingText.click();
     }

--- a/wayfarer-keyboard-review.user.js
+++ b/wayfarer-keyboard-review.user.js
@@ -501,8 +501,7 @@
 
     function showFullSupportingInfo() {
         if (document.getElementsByTagName('mat-dialog-container').length){
-            const parent = document.getElementsByClassName('cdk-overlay-container')[0];
-            while (parent.firstChild) { parent.removeChild(parent.firstChild); }
+            document.querySelector('div.cdk-overlay-backdrop.cdk-overlay-dark-backdrop.cdk-overlay-backdrop-showing').click();
             return;
         }
         const supportingText = document.querySelector('app-supporting-info .wf-review-card__body .bg-gray-200');


### PR DESCRIPTION
Set up using "A" again instead of esc to close the additional supporting info modal.