### PR TITLE
Added kart.1881.no and kart.finn.no to Norway maps

### DIFF
--- a/wayfarer-open-in.user.js
+++ b/wayfarer-open-in.user.js
@@ -372,6 +372,18 @@
         },
         {
             // Norway
+            label: 'Finn.no kart',
+            url: 'https://kart.finn.no/?lng=%lng%&lat=%lat%&zoom=16&mapType=norortho&showPin=1',
+            regions: ['NO']
+        },
+        {
+            // Norway
+            label: '1881.no kart',
+            url: 'https://kart.1881.no/?lat=%lat%&lon=%lon%&z=16&v=1&r=&o=&layer=',
+            regions: ['NO']
+        },
+        {
+            // Norway
             label: 'Gule Sider',
             url: 'https://kart.gulesider.no/?c=%lat%,%lng%&z=18&l=aerial&g=%lat%,%lng%',
             regions: ['NO']

--- a/wayfarer-open-in.user.js
+++ b/wayfarer-open-in.user.js
@@ -379,7 +379,7 @@
         {
             // Norway
             label: '1881.no kart',
-            url: 'https://kart.1881.no/?lat=%lat%&lon=%lon%&z=16&v=1&r=&o=&layer=',
+            url: 'https://kart.1881.no/?lat=%lat%&lon=%lng%&z=16&v=1&r=&o=&layer=',
             regions: ['NO']
         },
         {

--- a/wayfarer-open-in.user.js
+++ b/wayfarer-open-in.user.js
@@ -373,13 +373,13 @@
         {
             // Norway
             label: 'Finn.no kart',
-            url: 'https://kart.finn.no/?lng=%lng%&lat=%lat%&zoom=16&mapType=norortho&showPin=1',
+            url: 'https://kart.finn.no/?lng=%lng%&lat=%lat%&zoom=18&mapType=norortho&showPin=1',
             regions: ['NO']
         },
         {
             // Norway
             label: '1881.no kart',
-            url: 'https://kart.1881.no/?lat=%lat%&lon=%lng%&z=16&v=1&r=&o=&layer=',
+            url: 'https://kart.1881.no/?lat=%lat%&lon=%lng%&z=18&v=1&r=&o=&layer=',
             regions: ['NO']
         },
         {


### PR DESCRIPTION
Kart.finn.no has an excellent set of historical aerial photos and maps for Norway
Kart.1881.no has the same AND and option for ublique aerial photos from 4 directions for most large cities in Norway.

Tested locally in my wayfarer setup.