### PR TITLE
remove explicit grant

### DIFF
--- a/wayfarer-contribution-management-layout.user.js
+++ b/wayfarer-contribution-management-layout.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name         Wayfarer Contribution Management Layout
-// @version      0.0.1
+// @version      0.0.2
 // @description  Improves the layout of the Contribution Management page
 // @namespace    https://github.com/tehstone/wayfarer-addons/
 // @downloadURL  @downloadURL  https://github.com/tehstone/wayfarer-addons/raw/main/wayfarer-contribution-management-layout.user.js

--- a/wayfarer-contribution-management-layout.user.js
+++ b/wayfarer-contribution-management-layout.user.js
@@ -7,7 +7,6 @@
 // @homepageURL  https://github.com/tehstone/wayfarer-addons/
 // @match        https://wayfarer.nianticlabs.com/*
 // @run-at       document-start
-// @grant        GM_info
 // ==/UserScript==
 
 // Copyright 2024 Tntnnbltn


### PR DESCRIPTION
One of the only things logged about on iOS before nothing happens

confirmed that for some reason removing this fixes everything, and:
- I believe the effective behavior is supposed to be the same without any grant
- The GM_info function isn’t used