### PR TITLE
fix appeals off by one & timezone offset

### DIFF
--- a/wayfarer-appeal-info.user.js
+++ b/wayfarer-appeal-info.user.js
@@ -157,14 +157,20 @@ function init() {
                         if (minHours > 9) {
                             appeal.textContent = `in ~${minHours} hours`;
                         } else {
-                            const millisUntilFirst = Math.round(((firstAppealUTCDay + APPEAL_MILLIS) - current));
-                            const millisUntilSecond = Math.round(((secondAppealUTCDay + APPEAL_MILLIS) - current));
-                            const minMillis = Math.min(millisUntilFirst, millisUntilSecond);
-                            const hours = Math.floor(minMillis / HOUR_MILLIS);
-                            const remainingHourMillis = minMillis % HOUR_MILLIS;
-                            const minutes = Math.floor(remainingHourMillis / MINUTE_MILLIS).toString().padStart(2, "0");
-                            const seconds = Math.floor((remainingHourMillis % MINUTE_MILLIS) / SECOND_MILLIS).toString().padStart(2, "0");
-                            appeal.textContent = `in ${hours}:${minutes}:${seconds}`;
+                            const updateTimestamp = (currentTime) => {
+                                const millisUntilFirst = Math.round(((firstAppealUTCDay + APPEAL_MILLIS) - currentTime));
+                                const millisUntilSecond = Math.round(((secondAppealUTCDay + APPEAL_MILLIS) - currentTime));
+                                const minMillis = Math.min(millisUntilFirst, millisUntilSecond);
+                                const hours = Math.floor(minMillis / HOUR_MILLIS);
+                                const remainingHourMillis = minMillis % HOUR_MILLIS;
+                                const minutes = Math.floor(remainingHourMillis / MINUTE_MILLIS).toString().padStart(2, "0");
+                                const seconds = Math.floor((remainingHourMillis % MINUTE_MILLIS) / SECOND_MILLIS).toString().padStart(2, "0");
+                                appeal.textContent = `in ${hours}:${minutes}:${seconds}`;
+                            };
+                            updateTimestamp(current);
+                            setInterval(() => {
+                                updateTimestamp(Date.now());
+                            }, 1000);
                         }
                     }
                 }

--- a/wayfarer-appeal-info.user.js
+++ b/wayfarer-appeal-info.user.js
@@ -32,6 +32,10 @@
 function init() {
     const MAX_APPEALS = 2;
     const APPEAL_COOLDOWN = 20;
+    const MINUTE_MILLIS = 1000 * 60;
+    const HOUR_MILLIS = MINUTE_MILLIS * 60;
+    const DAY_MILLIS = HOUR_MILLIS * 24;
+    const APPEAL_MILLIS = (APPEAL_COOLDOWN * DAY_MILLIS);
     const OBJECT_STORE_NAME = 'appealInfo';
     const idMap = {};
     const statusMap = {};
@@ -122,8 +126,8 @@ function init() {
             const current = Date.now();
             const currentUTCDay = new Date(new Date(current).setUTCHours(0,0,0,0)).valueOf();
             // For day calculations, use UTC day
-            const daysUntilFirst = Math.round(((firstAppealUTCDay.valueOf() + (APPEAL_COOLDOWN * 1000 * 60 * 60 * 24) ) - currentUTCDay) / (1000 * 60 * 60 * 24));
-            const daysUntilSecond = Math.round(((secondAppealUTCDay.valueOf() + (APPEAL_COOLDOWN * 1000 * 60 * 60 * 24) ) - currentUTCDay) / (1000 * 60 * 60 * 24));
+            const daysUntilFirst = Math.round(((firstAppealUTCDay.valueOf() + APPEAL_MILLIS ) - currentUTCDay) / DAY_MILLIS);
+            const daysUntilSecond = Math.round(((secondAppealUTCDay.valueOf() + APPEAL_MILLIS ) - currentUTCDay) / DAY_MILLIS);
             if (daysUntilFirst <= 0 || daysUntilSecond <= 0) {
                 if (!canAppeal) {
                     appeal.textContent = 'No';
@@ -145,14 +149,14 @@ function init() {
                         appeal.textContent = `in ~${minDays} days`;
                     } else {
                         // For less-than-day calculations, use local time, but compared to the UTC day the appeal was made on
-                        const hoursUntilFirst = Math.round(((firstAppealUTCDay.valueOf() + (APPEAL_COOLDOWN * 1000 * 60 * 60 * 24) ) - current) / (1000 * 60 * 60));
-                        const hoursUntilSecond = Math.round(((secondAppealUTCDay.valueOf() + (APPEAL_COOLDOWN * 1000 * 60 * 60 * 24) ) - current) / (1000 * 60 * 60));
+                        const hoursUntilFirst = Math.round(((firstAppealUTCDay.valueOf() + APPEAL_MILLIS ) - current) / HOUR_MILLIS);
+                        const hoursUntilSecond = Math.round(((secondAppealUTCDay.valueOf() + APPEAL_MILLIS ) - current) / HOUR_MILLIS);
                         const minHours = Math.min(hoursUntilFirst, hoursUntilSecond);
                         if (minHours > 2) {
                             appeal.textContent = `in ~${minHours} hours`;
                         } else {
-                            const minsUntilFirst = Math.round(((firstAppealUTCDay.valueOf() + (APPEAL_COOLDOWN * 1000 * 60 * 60 * 24) ) - current) / (1000 * 60));
-                            const minsUntilSecond = Math.round(((secondAppealUTCDay.valueOf() + (APPEAL_COOLDOWN * 1000 * 60 * 60 * 24) ) - current) / (1000 * 60));
+                            const minsUntilFirst = Math.round(((firstAppealUTCDay.valueOf() + APPEAL_MILLIS ) - current) / MINUTE_MILLIS);
+                            const minsUntilSecond = Math.round(((secondAppealUTCDay.valueOf() + APPEAL_MILLIS ) - current) / MINUTE_MILLIS);
                             const minMins = Math.min(minsUntilFirst, minsUntilSecond);
                             appeal.textContent = `in ~${minMins} minutes`;
                         }

--- a/wayfarer-appeal-info.user.js
+++ b/wayfarer-appeal-info.user.js
@@ -31,7 +31,8 @@
 
 function init() {
     const MAX_APPEALS = 2;
-    const APPEAL_COOLDOWN = 20;
+    const APPEAL_COOLDOWN_DAYS = 20; // number of days appeal cooldown
+    const APPEAL_COOLDOWN = APPEAL_COOLDOWN_DAYS + 1; // exclude day appeal made
     const SECOND_MILLIS = 1000;
     const MINUTE_MILLIS = SECOND_MILLIS * 60;
     const HOUR_MILLIS = MINUTE_MILLIS * 60;


### PR DESCRIPTION
Adds finer grained measurements as the day approaches (making it painfully obvious if it’s wrong), uses the actual time appeals will refresh for calculations, and fixes including the day of appeal when counting.

probably actually correct today since it was off by one yesterday and I bothered to count the days manually this time, but maybe give it another 7-ish hours (not that it’s likely to get merged faster than that) for me to verify that I actually get my next set of appeals.