### PR TITLE
add @match directive for opr.ingress.com domain to all userscripts

### DIFF
--- a/wayfarer-achievements.user.js
+++ b/wayfarer-achievements.user.js
@@ -6,6 +6,7 @@
 // @downloadURL  https://github.com/tehstone/wayfarer-addons/raw/main/wayfarer-achievements.user.js
 // @homepageURL  https://github.com/tehstone/wayfarer-addons/
 // @match        https://wayfarer.nianticlabs.com/*
+// @match        https://opr.ingress.com/*
 // @run-at       document-start
 // ==/UserScript==
 

--- a/wayfarer-appeal-info.user.js
+++ b/wayfarer-appeal-info.user.js
@@ -6,6 +6,7 @@
 // @downloadURL  https://github.com/tehstone/wayfarer-addons/raw/main/wayfarer-appeal-info.user.js
 // @homepageURL  https://github.com/tehstone/wayfarer-addons/
 // @match        https://wayfarer.nianticlabs.com/*
+// @match        https://opr.ingress.com/*
 // ==/UserScript==
 
 // Copyright 2024 tehstone

--- a/wayfarer-compact-card.user.js
+++ b/wayfarer-compact-card.user.js
@@ -6,6 +6,7 @@
 // @downloadURL  https://github.com/tehstone/wayfarer-addons/raw/main/wayfarer-compact-card.user.js
 // @homepageURL  https://github.com/tehstone/wayfarer-addons/
 // @match        https://wayfarer.nianticlabs.com/*
+// @match        https://opr.ingress.com/*
 // ==/UserScript==
 
 // Copyright 2024 tehstone

--- a/wayfarer-contribution-management-layout.user.js
+++ b/wayfarer-contribution-management-layout.user.js
@@ -7,6 +7,7 @@
 // @updateUrl    https://github.com/tehstone/wayfarer-addons/raw/main/wayfarer-contribution-management-layout.user.js
 // @homepageURL  https://github.com/tehstone/wayfarer-addons/
 // @match        https://wayfarer.nianticlabs.com/*
+// @match        https://opr.ingress.com/*
 // @run-at       document-start
 // ==/UserScript==
 

--- a/wayfarer-edits-diff.user.js
+++ b/wayfarer-edits-diff.user.js
@@ -7,6 +7,7 @@
 // @homepageURL  https://github.com/tehstone/wayfarer-addons
 // @require      https://cdnjs.cloudflare.com/ajax/libs/jsdiff/5.0.0/diff.min.js
 // @match        https://wayfarer.nianticlabs.com/*
+// @match        https://opr.ingress.com/*
 // ==/UserScript==
 
 // Copyright 2024 bilde, tehstone

--- a/wayfarer-email-api.user.js
+++ b/wayfarer-email-api.user.js
@@ -6,6 +6,7 @@
 // @downloadURL  https://github.com/tehstone/wayfarer-addons/raw/main/wayfarer-email-api.user.js
 // @homepageURL  https://github.com/tehstone/wayfarer-addons/
 // @match        https://wayfarer.nianticlabs.com/*
+// @match        https://opr.ingress.com/*
 // @run-at       document-start
 // ==/UserScript==
 

--- a/wayfarer-extended-stats.user.js
+++ b/wayfarer-extended-stats.user.js
@@ -6,6 +6,7 @@
 // @downloadURL  https://github.com/tehstone/wayfarer-addons/raw/main/wayfarer-extended-stats.user.js
 // @homepageURL  https://github.com/tehstone/wayfarer-addons/
 // @match        https://wayfarer.nianticlabs.com/*
+// @match        https://opr.ingress.com/*
 // @run-at       document-start
 // ==/UserScript==
 

--- a/wayfarer-keyboard-review.user.js
+++ b/wayfarer-keyboard-review.user.js
@@ -6,6 +6,7 @@
 // @downloadURL  https://github.com/tehstone/wayfarer-addons/raw/main/wayfarer-keyboard-review.user.js
 // @homepageURL  https://github.com/tehstone/wayfarer-addons
 // @match        https://wayfarer.nianticlabs.com/*
+// @match        https://opr.ingress.com/*
 // @run-at       document-start
 // ==/UserScript==
 

--- a/wayfarer-localstoragecheck.user.js
+++ b/wayfarer-localstoragecheck.user.js
@@ -6,6 +6,7 @@
 // @downloadURL  https://github.com/tehstone/wayfarer-addons/raw/main/wayfarer-localstoragecheck.user.js
 // @homepageURL  https://github.com/tehstone/wayfarer-addons/
 // @match        https://wayfarer.nianticlabs.com/*
+// @match        https://opr.ingress.com/*
 // ==/UserScript==
 
 // Copyright 2024 tehstone, bilde

--- a/wayfarer-nomination-map.user.js
+++ b/wayfarer-nomination-map.user.js
@@ -6,6 +6,7 @@
 // @downloadURL  https://github.com/tehstone/wayfarer-addons/raw/main/wayfarer-nomination-map.user.js
 // @homepageURL  https://github.com/tehstone/wayfarer-addons/
 // @match        https://wayfarer.nianticlabs.com/*
+// @match        https://opr.ingress.com/*
 // ==/UserScript==
 
 // Copyright 2024 tehstone, bilde, Tntnnbltn

--- a/wayfarer-nomination-stats.user.js
+++ b/wayfarer-nomination-stats.user.js
@@ -6,6 +6,7 @@
 // @downloadURL  https://github.com/tehstone/wayfarer-addons/raw/main/wayfarer-nomination-stats.user.js
 // @homepageURL  https://github.com/tehstone/wayfarer-addons/
 // @match        https://wayfarer.nianticlabs.com/*
+// @match        https://opr.ingress.com/*
 // ==/UserScript==
 
 // Copyright 2024 tehstone, Tntnnbltn

--- a/wayfarer-nomination-status-history.user.js
+++ b/wayfarer-nomination-status-history.user.js
@@ -6,6 +6,7 @@
 // @downloadURL  https://github.com/tehstone/wayfarer-addons/raw/main/wayfarer-nomination-status-history.user.js
 // @homepageURL  https://github.com/tehstone/wayfarer-addons/
 // @match        https://wayfarer.nianticlabs.com/*
+// @match        https://opr.ingress.com/*
 // @run-at       document-start
 // @grant        GM_info
 // ==/UserScript==

--- a/wayfarer-nomination-streetview.user.js
+++ b/wayfarer-nomination-streetview.user.js
@@ -6,6 +6,7 @@
 // @downloadURL  https://github.com/tehstone/wayfarer-addons/raw/main/wayfarer-nomination-streetview.user.js
 // @homepageURL  https://github.com/tehstone/wayfarer-addons/
 // @match        https://wayfarer.nianticlabs.com/*
+// @match        https://opr.ingress.com/*
 // ==/UserScript==
 
 // Copyright 2024 tehstone, Tntnnbltn

--- a/wayfarer-nomination-types.user.js
+++ b/wayfarer-nomination-types.user.js
@@ -6,6 +6,7 @@
 // @downloadURL  https://github.com/tehstone/wayfarer-addons/raw/main/wayfarer-nomination-types.user.js
 // @homepageURL  https://github.com/tehstone/wayfarer-addons/
 // @match        https://wayfarer.nianticlabs.com/*
+// @match        https://opr.ingress.com/*
 // ==/UserScript==
 
 // Copyright 2024 tehstone, bilde

--- a/wayfarer-open-in.user.js
+++ b/wayfarer-open-in.user.js
@@ -6,6 +6,7 @@
 // @downloadURL  https://github.com/tehstone/wayfarer-addons/raw/main/wayfarer-open-in.user.js
 // @homepageURL  https://github.com/tehstone/wayfarer-addons
 // @match        https://wayfarer.nianticlabs.com/*
+// @match        https://opr.ingress.com/*
 // @match        https://www.geobenin.bj/carto/www/
 // @match        https://www.geoland.at/webgisviewer/geoland/map/Geoland_Viewer/Geoland
 // @match        https://www.geoportal-bw.de/

--- a/wayfarer-prime-portal-links.user.js
+++ b/wayfarer-prime-portal-links.user.js
@@ -6,6 +6,7 @@
 // @downloadURL  https://github.com/tehstone/wayfarer-addons/raw/main/wayfarer-prime-portal-links.user.js
 // @homepageURL  https://github.com/tehstone/wayfarer-addons
 // @match        https://wayfarer.nianticlabs.com/*
+// @match        https://opr.ingress.com/*
 // ==/UserScript==
 
 // Copyright 2024 tehstone

--- a/wayfarer-rejections-plus.user.js
+++ b/wayfarer-rejections-plus.user.js
@@ -6,6 +6,7 @@
 // @downloadURL  https://github.com/tehstone/wayfarer-addons/raw/main/wayfarer-rejections-plus.user.js
 // @homepageURL  https://github.com/tehstone/wayfarer-addons/
 // @match        https://wayfarer.nianticlabs.com/*
+// @match        https://opr.ingress.com/*
 // @run-at       document-start
 // ==/UserScript==
 

--- a/wayfarer-reverse-image-search.user.js
+++ b/wayfarer-reverse-image-search.user.js
@@ -6,6 +6,7 @@
 // @downloadURL  https://github.com/tehstone/wayfarer-addons/raw/main/wayfarer-reverse-image-search.user.js
 // @homepageURL  https://github.com/tehstone/wayfarer-addons
 // @match        https://wayfarer.nianticlabs.com/*
+// @match        https://opr.ingress.com/*
 // ==/UserScript==
 
 // Copyright 2024 tehstone, bilde

--- a/wayfarer-review-counter.user.js
+++ b/wayfarer-review-counter.user.js
@@ -6,6 +6,7 @@
 // @downloadURL  https://github.com/tehstone/wayfarer-addons/raw/main/wayfarer-review-counter.user.js
 // @homepageURL  https://github.com/tehstone/wayfarer-addons
 // @match        https://wayfarer.nianticlabs.com/*
+// @match        https://opr.ingress.com/*
 // ==/UserScript==
 
 // Copyright 2024 tehstone, bilde

--- a/wayfarer-review-history-idb.user.js
+++ b/wayfarer-review-history-idb.user.js
@@ -6,6 +6,7 @@
 // @downloadURL  https://github.com/tehstone/wayfarer-addons/raw/main/wayfarer-review-history-idb.user.js
 // @homepageURL  https://github.com/tehstone/wayfarer-addons
 // @match        https://wayfarer.nianticlabs.com/*
+// @match        https://opr.ingress.com/*
 // @run-at       document-start
 // ==/UserScript==
 

--- a/wayfarer-review-history-table.user.js
+++ b/wayfarer-review-history-table.user.js
@@ -5,6 +5,7 @@
 // @namespace    https://github.com/tehstone/wayfarer-addons
 // @homepageURL  https://github.com/tehstone/wayfarer-addons
 // @match        https://wayfarer.nianticlabs.com/*
+// @match        https://opr.ingress.com/*
 // @run-at       document-start
 // @require      https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js
 // @require      https://cdn.datatables.net/1.12.1/js/jquery.dataTables.min.js

--- a/wayfarer-review-map-mods.user.js
+++ b/wayfarer-review-map-mods.user.js
@@ -6,6 +6,7 @@
 // @downloadURL  https://github.com/tehstone/wayfarer-addons/raw/main/wayfarer-review-map-mods.user.js
 // @homepageURL  https://github.com/tehstone/wayfarer-addons
 // @match        https://wayfarer.nianticlabs.com/*
+// @match        https://opr.ingress.com/*
 // @run-at       document-start
 // ==/UserScript==
 

--- a/wayfarer-review-pings.user.js
+++ b/wayfarer-review-pings.user.js
@@ -6,6 +6,7 @@
 // @downloadURL  https://github.com/tehstone/wayfarer-addons/raw/main/wayfarer-review-pings.user.js
 // @homepageURL  https://github.com/tehstone/wayfarer-addons
 // @match        https://wayfarer.nianticlabs.com/*
+// @match        https://opr.ingress.com/*
 // ==/UserScript==
 
 // Copyright 2024 tehstone

--- a/wayfarer-review-timer.user.js
+++ b/wayfarer-review-timer.user.js
@@ -6,6 +6,7 @@
 // @downloadURL  https://github.com/tehstone/wayfarer-addons/raw/main/wayfarer-review-timer.user.js
 // @homepageURL  https://github.com/tehstone/wayfarer-addons
 // @match        https://wayfarer.nianticlabs.com/*
+// @match        https://opr.ingress.com/*
 // ==/UserScript==
 
 // Copyright 2024 tehstone, bilde

--- a/wayfarer-skip-count.user.js
+++ b/wayfarer-skip-count.user.js
@@ -6,6 +6,7 @@
 // @downloadURL  https://github.com/tehstone/wayfarer-addons/raw/main/wayfarer-skip-count.user.js
 // @homepageURL  https://github.com/tehstone/wayfarer-addons
 // @match        https://wayfarer.nianticlabs.com/*
+// @match        https://opr.ingress.com/*
 // ==/UserScript==
 
 /* eslint-env es6 */

--- a/wayfarer-ticket-saver.user.js
+++ b/wayfarer-ticket-saver.user.js
@@ -6,6 +6,7 @@
 // @downloadURL  https://github.com/tehstone/wayfarer-addons/raw/main/wayfarer-ticket-saver.user.js
 // @homepageURL  https://github.com/tehstone/wayfarer-addons
 // @match        https://wayfarer.nianticlabs.com/*
+// @match        https://opr.ingress.com/*
 // @match        https://webchat.helpshift.com/*
 // @grant        GM_setValue
 // @grant        GM_getValue

--- a/wayfarer-translate.user.js
+++ b/wayfarer-translate.user.js
@@ -6,6 +6,7 @@
 // @downloadURL  https://github.com/tehstone/wayfarer-addons/raw/main/wayfarer-translate.user.js
 // @homepageURL  https://github.com/tehstone/wayfarer-addons
 // @match        https://wayfarer.nianticlabs.com/*
+// @match        https://opr.ingress.com/*
 // ==/UserScript==
 
 // Copyright 2024 AlfonsoML, tehstone, bilde

--- a/wayfarer-upgrade-percent.user.js
+++ b/wayfarer-upgrade-percent.user.js
@@ -6,6 +6,7 @@
 // @downloadURL  https://github.com/tehstone/wayfarer-addons/raw/main/wayfarer-upgrade-percentage.user.js
 // @homepageURL  https://github.com/tehstone/wayfarer-addons
 // @match        https://wayfarer.nianticlabs.com/*
+// @match        https://opr.ingress.com/*
 // ==/UserScript==
 
 // Copyright 2024 tehstone

--- a/wayfarer-version-display.user.js
+++ b/wayfarer-version-display.user.js
@@ -6,6 +6,7 @@
 // @downloadURL  https://github.com/tehstone/wayfarer-addons/raw/main/wayfarer-version-display.user.js
 // @homepageURL  https://github.com/tehstone/wayfarer-addons
 // @match        https://wayfarer.nianticlabs.com/new/*
+// @match        https://opr.ingress.com/*
 // ==/UserScript==
 
 // Copyright 2024 tehstone, bilde


### PR DESCRIPTION
Added @match https://opr.ingress.com/* to all 29 userscript files to ensure compatibility with the new OPR Ingress domain while maintaining support for the existing wayfarer.nianticlabs.com domain.

🤖 Generated with [Claude Code](https://claude.ai/code)