### PR TITLE
fix wayfarer profile page addons after update

### DIFF
--- a/wayfarer-extended-stats.user.js
+++ b/wayfarer-extended-stats.user.js
@@ -90,7 +90,7 @@ function init() {
                 console.warn('Wayfarer\'s response didn\'t include a candidate.');
                 return;
             }
-            awaitElement(() => document.querySelector('wf-rating-bar'))
+            awaitElement(() => document.querySelector('wf-credibility-card'))
             .then((ref) => {
                 addSettings();
                 addCopyLink();
@@ -158,7 +158,7 @@ function init() {
             settingsContainer.appendChild(collapsibleLabel);
             settingsContainer.appendChild(collapsibleContent);
 
-            const ratingNarRef = document.querySelector('wf-rating-bar');
+            const ratingNarRef = document.querySelector('wf-credibility-card');
             const container = ratingNarRef.parentNode.parentNode;
             container.appendChild(settingsContainer);
         }
@@ -410,7 +410,7 @@ function init() {
         div.appendChild(document.createElement('br'));
         div.appendChild(exportButton);
 
-        const ref = document.querySelector('wf-rating-bar');
+        const ref = document.querySelector('wf-credibility-card');
         const container = ref.parentNode;
         container.appendChild(div);
 

--- a/wayfarer-review-history-idb.user.js
+++ b/wayfarer-review-history-idb.user.js
@@ -191,7 +191,7 @@
         }))
     };
 
-    const addRHButtons = () => awaitElement(() => document.querySelector('wf-rating-bar')).then(ref => {
+    const addRHButtons = () => awaitElement(() => document.querySelector('wf-credibility-card')).then(ref => {
         const outer = document.createElement('div');
         outer.id = 'wfrh-idb-topbar';
         outer.classList.add('wfrh-idb');
@@ -391,7 +391,7 @@
         return d;
     }
 
-    const addSettings = () => awaitElement(() =>document.querySelector('wf-rating-bar')).then(ref => {
+    const addSettings = () => awaitElement(() =>document.querySelector('wf-credibility-card')).then(ref => {
         let settingsDiv = document.getElementById("profileSettings");
         if (settingsDiv === null) {
             settingsDiv = document.createElement('div');
@@ -420,7 +420,7 @@
             settingsContainer.appendChild(collapsibleLabel);
             settingsContainer.appendChild(collapsibleContent);
 
-            const ratingNarRef = document.querySelector('wf-rating-bar');
+            const ratingNarRef = document.querySelector('wf-credibility-card');
             const container = ratingNarRef.parentNode.parentNode;
             container.appendChild(settingsContainer);
         }

--- a/wayfarer-review-history-table.user.js
+++ b/wayfarer-review-history-table.user.js
@@ -185,7 +185,7 @@
         displayPhotoTable.classList.add('wayfarerns__button');
         tableSelectorContainer.appendChild(displayPhotoTable);
 
-        const ratingNarRef = document.querySelector('wf-rating-bar');
+        const ratingNarRef = document.querySelector('wf-credibility-card');
         const container = ratingNarRef.parentNode.parentNode;
         container.appendChild(tableSelectorContainer);
     }
@@ -204,16 +204,16 @@
     function renderTable(reviewData) {
       const tableContainer = document.createElement("div");
       tableContainer.id = "nomination-table";
-      tableContainer.classList.add("table");
+      tableContainer.classList.add("review-history-table");
       tableContainer.style.display = "block";
       tableContainer.insertAdjacentHTML("beforeend",
         `
         <div class="table-responsive">
-                <table class="table table-striped table-condensed" id="review-history">
+                <table class="review-history-table table-striped table-condensed" id="review-history">
                 </table>
             </div>
         `)
-      const ratingNarRef = document.querySelector('wf-rating-bar');
+      const ratingNarRef = document.querySelector('wf-credibility-card');
       const container = ratingNarRef.parentNode.parentNode;
       container.appendChild(tableContainer);
 
@@ -424,16 +424,16 @@
     function renderEditsTable(reviewData) {
       const tableContainer = document.createElement("div");
       tableContainer.id = "edit-table";
-      tableContainer.classList.add("table");
+      tableContainer.classList.add("review-history-table");
       tableContainer.style.display = "none";
       tableContainer.insertAdjacentHTML("beforeend",
         `
         <div class="table-responsive">
-                <table class="table table-striped table-condensed" id="edit-review-history">
+                <table class="review-history-table table-striped table-condensed" id="edit-review-history">
                 </table>
             </div>
         `)
-      const ratingNarRef = document.querySelector('wf-rating-bar');
+      const ratingNarRef = document.querySelector('wf-credibility-card');
       const container = ratingNarRef.parentNode.parentNode;
       container.appendChild(tableContainer);
 
@@ -603,7 +603,7 @@
             rows.push(`<tr><td class="text-center">${selected}</td><td class="text-center">${content}</td></tr>`);
         });
         return `
-        <table class="table table-condensed scores">
+        <table class="review-history-table table-condensed scores">
           <thead>
               <tr>
                   <th class="text-center">Selected</th>
@@ -621,16 +621,16 @@
         console.log("history table click here");
       const tableContainer = document.createElement("div");
       tableContainer.id = "photo-table";
-      tableContainer.classList.add("table");
+      tableContainer.classList.add("review-history-table");
       tableContainer.style.display = "none";
       tableContainer.insertAdjacentHTML("beforeend",
         `
         <div class="table-responsive">
-                <table class="table table-striped table-condensed" id="photo-review-history">
+                <table class="review-history-table table-striped table-condensed" id="photo-review-history">
                 </table>
             </div>
         `)
-      const ratingNarRef = document.querySelector('wf-rating-bar');
+      const ratingNarRef = document.querySelector('wf-credibility-card');
       const container = ratingNarRef.parentNode.parentNode;
       container.appendChild(tableContainer);
 
@@ -812,7 +812,7 @@
                 return "";
             }
             return `
-            <table class="table table-condensed scores">
+            <table class="review-history-table table-condensed scores">
               <thead>
                   <tr>
                       <th class="text-center">Score</th>
@@ -858,7 +858,7 @@
             return rejections.join("<br />");
         } else {
             return `
-                <table class="table table-condensed scores">
+                <table class="review-history-table table-condensed scores">
                   <thead>
                       <tr>
                           <th class="text-center">Appropriate</th>


### PR DESCRIPTION
This PR fixes (hopefully) the Extended Stats, Review History, and Review History Table addons. `wf-rating-bar` was renamed `wf-credibility-card` so I just updated the querySelectors.

Review History table also had a display bug where all three tables were displaying at once. There was a new CSS rule in the wayfarer CSS for:

```
.table {
    display: table !important;
}
```

that was causing all three to display at once, not just the selected one. I went through and renamed the `table` class to `review-history-table` where it was being used in the addon which appears to have fixed the bug.